### PR TITLE
Make check for `+dune` accept `+dune[digit]` as well

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -14,6 +14,7 @@
  (description "`duniverse-lint` checks ports to `dune` for correctness")
  (depends
   (ocaml (>= 4.11.0))
+  (alcotest (and :with-test (>= 1.5.0)))
   (base (>= v0.14))
   (cmdliner (>= 1.0.4))
   (opam-file-format (>= 2.1.2))

--- a/dune-project
+++ b/dune-project
@@ -18,5 +18,6 @@
   (cmdliner (>= 1.0.4))
   (opam-file-format (>= 2.1.2))
   (opam-format (>= 2.1.0))
+  (re (>= 1.10.3))
   (sexplib (>= v0.14))
   (stdio (>= v0.14))))

--- a/duniverse-lint.opam
+++ b/duniverse-lint.opam
@@ -10,6 +10,7 @@ bug-reports: "https://github.com/dune-universe/duniverse-lint/issues"
 depends: [
   "dune" {>= "2.9"}
   "ocaml" {>= "4.11.0"}
+  "alcotest" {with-test & >= "1.5.0"}
   "base" {>= "v0.14"}
   "cmdliner" {>= "1.0.4"}
   "opam-file-format" {>= "2.1.2"}

--- a/duniverse-lint.opam
+++ b/duniverse-lint.opam
@@ -14,6 +14,7 @@ depends: [
   "cmdliner" {>= "1.0.4"}
   "opam-file-format" {>= "2.1.2"}
   "opam-format" {>= "2.1.0"}
+  "re" {>= "1.10.3"}
   "sexplib" {>= "v0.14"}
   "stdio" {>= "v0.14"}
   "odoc" {with-doc}

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name duniverse_lint)
- (libraries stdio sexplib opam-format))
+ (libraries stdio sexplib opam-format re))

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -62,3 +62,8 @@ let opam_uses_dune path =
   in
   let* () = dune_in_build opam.build in
   Ok ()
+
+(* code that is exposed for tests but not part of the API *)
+module Private = struct
+  let check_version = check_version
+end

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -2,10 +2,11 @@ open Base
 open O
 module Sexp = Sexplib.Sexp
 
+let dune_n = Re.(seq [ str "+dune"; rep digit; eol ]) |> Re.compile
+
 let check_version version =
-  version
-  |> String.is_suffix ~suffix:"+dune"
-  |> Result.ok_if_true ~error:(`Msg "Version is missing +dune")
+  version |> Re.execp dune_n
+  |> Result.ok_if_true ~error:(`Msg "Version is missing +dune suffix")
 
 type dune_project = { name : string; version : string }
 

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,3 +1,23 @@
-val check_version : string -> (unit, [ `Msg of string ]) result
 val check_dune_project : string -> (unit, [ `Msg of string ]) result
+(** [check_dune_project s] checks whether the [dune-project] file at [s] is
+    valid and returns with an error if not.
+
+    Validity is determined by:
+    - Does the version include the [+dune] suffix?
+    - Is the [name] specified?
+    *)
+
 val opam_uses_dune : string -> (unit, [ `Msg of string ]) result
+(** [opam_uses_dune s] checks whether the OPAM file at [s] uses the dune binary
+    in the build instructions of the OPAM file. It doesn't check whether dune
+    actually will build the artifacts but is just an heuristic. *)
+
+(**/**)
+
+(* Undocumented: internal and only exposed for tests *)
+
+module Private : sig
+  val check_version : string -> (unit, [ `Msg of string ]) result
+end
+
+(**/**)

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,2 +1,3 @@
+val check_version : string -> (unit, [ `Msg of string ]) result
 val check_dune_project : string -> (unit, [ `Msg of string ]) result
 val opam_uses_dune : string -> (unit, [ `Msg of string ]) result

--- a/test/dune
+++ b/test/dune
@@ -1,0 +1,3 @@
+(test
+ (name test)
+ (libraries alcotest duniverse_lint))

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,0 +1,1 @@
+let () = Alcotest.run "Lint" [ Test_version.tests ]

--- a/test/test_version.ml
+++ b/test/test_version.ml
@@ -1,0 +1,27 @@
+let pp_msg ppf = function `Msg s -> Format.fprintf ppf "%s" s
+
+let equal_msg a b =
+  match (a, b) with
+  (* We don't really care about the wording of the error *)
+  | `Msg _, `Msg _ -> true
+  | _, _ -> false
+
+let message = Alcotest.testable pp_msg equal_msg
+let result = Alcotest.result Alcotest.unit message
+let verify = Duniverse_lint.Lint.check_version
+
+let test_dune_suffix () =
+  let valid = Ok () in
+  let invalid = Error (`Msg "_") in
+  Alcotest.check result "Regular valid" valid (verify "1.0+dune");
+  Alcotest.check result "Revised valid" valid (verify "1.0+dune2");
+  Alcotest.check result "Non-alphanumeric revised" invalid (verify "1.0+duneN");
+  Alcotest.check result "Missing suffix" invalid (verify "1.0");
+  Alcotest.check result "Not a suffix" invalid (verify "+dune1.0");
+  Alcotest.check result "Whitespace suffix" invalid (verify "1.0+dune ");
+  Alcotest.check result "Multiple suffixes" valid (verify "1.0+mirage+dune");
+  Alcotest.check result "Multiple identical suffixes" valid
+    (verify "1.0+dune+dune")
+
+let test_case = Alcotest.test_case
+let tests = ("version", [ test_case "Dune suffix" `Quick test_dune_suffix ])

--- a/test/test_version.ml
+++ b/test/test_version.ml
@@ -8,7 +8,7 @@ let equal_msg a b =
 
 let message = Alcotest.testable pp_msg equal_msg
 let result = Alcotest.result Alcotest.unit message
-let verify = Duniverse_lint.Lint.check_version
+let verify = Duniverse_lint.Lint.Private.check_version
 
 let test_dune_suffix () =
   let valid = Ok () in


### PR DESCRIPTION
Sometimes we need to re-release a dune port, but the existing dune port is out there and in use, so it makes more sense to make a new release. For this case we decided to use `+dune2`, `+dune3` etc. so this PR extends the logic to allow digits as well.