### PR TITLE
Require a lower minimum version of OCaml

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -13,7 +13,7 @@
  (synopsis "Checks duniverse ports for correctness")
  (description "`duniverse-lint` checks ports to `dune` for correctness")
  (depends
-  (ocaml (>= 4.13.0))
+  (ocaml (>= 4.11.0))
   (base (>= v0.14))
   (cmdliner (>= 1.0.4))
   (opam-file-format (>= 2.1.2))

--- a/duniverse-lint.opam
+++ b/duniverse-lint.opam
@@ -9,7 +9,7 @@ homepage: "https://github.com/dune-universe/duniverse-lint"
 bug-reports: "https://github.com/dune-universe/duniverse-lint/issues"
 depends: [
   "dune" {>= "2.9"}
-  "ocaml" {>= "4.13.0"}
+  "ocaml" {>= "4.11.0"}
   "base" {>= "v0.14"}
   "cmdliner" {>= "1.0.4"}
   "opam-file-format" {>= "2.1.2"}


### PR DESCRIPTION
We probably don't use any of the more modern features anyway.