### PR TITLE
Return error code when lint failed

### DIFF
--- a/bin/lint.ml
+++ b/bin/lint.ml
@@ -11,10 +11,12 @@ let check () =
 
 let main () =
   match check () with
-  | Ok () -> ()
-  | Error (`Msg msg) -> Stdio.print_endline msg
+  | Ok () -> 0
+  | Error (`Msg msg) ->
+      Stdio.print_endline msg;
+      1
 
 let () =
   let open Cmdliner in
   let duniverse_lint = Term.(const main $ const ()) in
-  Term.exit @@ Term.eval (duniverse_lint, Term.info "duniverse-lint")
+  Term.exit_status @@ Term.eval (duniverse_lint, Term.info "duniverse-lint")


### PR DESCRIPTION
Despite `Term.exit` supposedly testing for the return status of the command it was always returning 0, even when there were linting errors, which makes it hard to detect whether linting succeeded or failed.