### PR TITLE
Check whether base version exists in OPAM repository

### DIFF
--- a/dune-project
+++ b/dune-project
@@ -20,6 +20,7 @@
   (fmt (>= 0.9.0))
   (opam-file-format (>= 2.1.2))
   (opam-format (>= 2.1.0))
+  (opam-state (>= 2.1.0))
   (re (>= 1.10.3))
   (sexplib (>= v0.14))
   (stdio (>= v0.14))))

--- a/duniverse-lint.opam
+++ b/duniverse-lint.opam
@@ -16,6 +16,7 @@ depends: [
   "fmt" {>= "0.9.0"}
   "opam-file-format" {>= "2.1.2"}
   "opam-format" {>= "2.1.0"}
+  "opam-state" {>= "2.1.0"}
   "re" {>= "1.10.3"}
   "sexplib" {>= "v0.14"}
   "stdio" {>= "v0.14"}

--- a/lib/dune
+++ b/lib/dune
@@ -1,3 +1,3 @@
 (library
  (name duniverse_lint)
- (libraries stdio sexplib opam-format re fmt))
+ (libraries stdio sexplib opam-format opam-state re fmt))

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -25,6 +25,8 @@ val all : label:string -> check list -> check
 module Private : sig
   val check_version :
     string -> [ `Finished of (unit, [ `Msg of string ]) result ]
+
+  val upstream_version : string -> string
 end
 
 (**/**)

--- a/lib/pp.ml
+++ b/lib/pp.ml
@@ -1,0 +1,1 @@
+let package = Fmt.using OpamPackage.to_string Fmt.string

--- a/lib/pp.mli
+++ b/lib/pp.mli
@@ -1,0 +1,1 @@
+val package : OpamPackage.t Fmt.t

--- a/test/test.ml
+++ b/test/test.ml
@@ -1,1 +1,1 @@
-let () = Alcotest.run "Lint" [ Test_version.tests ]
+let () = Alcotest.run "Lint" [ Test_version.tests; Test_upstream_version.tests ]

--- a/test/test_upstream_version.ml
+++ b/test/test_upstream_version.ml
@@ -1,0 +1,17 @@
+let test name ~port ~upstream () =
+  let upstreamed = Duniverse_lint.Lint.Private.upstream_version port in
+  Alcotest.(check string) name upstreamed upstream
+
+let mk_test name ~port ~upstream =
+  Alcotest.test_case name `Quick (test name ~port ~upstream)
+
+let test_cases =
+  [
+    mk_test "No changes" ~port:"1.0" ~upstream:"1.0";
+    mk_test "Just +dune" ~port:"1.0+dune" ~upstream:"1.0";
+    mk_test "Revised +dune" ~port:"1.0+dune2" ~upstream:"1.0";
+    mk_test "Suffix twice" ~port:"1.0+dune1+dune2" ~upstream:"1.0+dune1";
+    mk_test "Multiple suffixes" ~port:"1.0+mirage+dune" ~upstream:"1.0+mirage";
+  ]
+
+let tests = ("upstream version", test_cases)


### PR DESCRIPTION
We want to avoid packaging ports where the base version does not exists, so the linter should check OPAM whether a package with the base version is known to exist.

Closes #5.