### PR TITLE
Allow +dune+mirage suffix in packages

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,3 @@
+# .git-blame-ignore-revs
+# updated ocamlformat to 0.29
+14685e95e04f70c9587888b299e7b4ba0a68e6d0

--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,1 +1,1 @@
-version=0.20.1
+version=0.29.0

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -17,13 +17,14 @@ type check = {
     The function as two options: if this is the only check that it can do, it
     should return [`Finished] of the lint result. But if as part of this check
     more checks are enabled (e.g. checking for existence of a file enables
-    checking of the syntax of the file) then it can return its own check
-    result, as well as further recursive checks using [`Recursive].
-*)
+    checking of the syntax of the file) then it can return its own check result,
+    as well as further recursive checks using [`Recursive]. *)
 
 let lint ~label f = { label; f }
-let mirage_n = Re.(seq [ str "+mirage"; rep digit])
-let dune_n = Re.(seq [ str "+dune"; rep digit; opt mirage_n; eol ]) |> Re.compile
+let mirage_n = Re.(seq [ str "+mirage"; rep digit ])
+
+let dune_n =
+  Re.(seq [ str "+dune"; rep digit; opt mirage_n; eol ]) |> Re.compile
 
 let check_version version =
   match version |> Re.execp dune_n with
@@ -88,13 +89,13 @@ let dune_in_build_check build =
   let r =
     build
     |> List.fold ~init:false ~f:(fun uses_dune (args, _filter) ->
-           match uses_dune with
-           | true -> true
-           | false -> (
-               match List.hd args with
-               | None -> uses_dune
-               | Some (OpamTypes.CString "dune", _) -> true
-               | Some _ -> false))
+        match uses_dune with
+        | true -> true
+        | false -> (
+            match List.hd args with
+            | None -> uses_dune
+            | Some (OpamTypes.CString "dune", _) -> true
+            | Some _ -> false))
   in
   match r with
   | true -> `Finished (Ok ())

--- a/lib/lint.ml
+++ b/lib/lint.ml
@@ -22,7 +22,8 @@ type check = {
 *)
 
 let lint ~label f = { label; f }
-let dune_n = Re.(seq [ str "+dune"; rep digit; eol ]) |> Re.compile
+let mirage_n = Re.(seq [ str "+mirage"; rep digit])
+let dune_n = Re.(seq [ str "+dune"; rep digit; opt mirage_n; eol ]) |> Re.compile
 
 let check_version version =
   match version |> Re.execp dune_n with

--- a/lib/lint.mli
+++ b/lib/lint.mli
@@ -1,13 +1,12 @@
 type check
 
 val dune_project : string -> check
-(** [dune_project s] checks whether the [dune-project] file at [s] is
-    valid and returns with an error if not.
+(** [dune_project s] checks whether the [dune-project] file at [s] is valid and
+    returns with an error if not.
 
     Validity is determined by:
     - Does the version include the [+dune] suffix?
-    - Is the [name] specified?
-    *)
+    - Is the [name] specified? *)
 
 val eval : check -> (unit, [ `Msg of string ]) Result.t list
 

--- a/test/test_version.ml
+++ b/test/test_version.ml
@@ -38,10 +38,13 @@ let test_cases =
     mk_test valid "Revised valid" "1.0+dune2";
     mk_test valid "Multiple suffixes" "1.0+mirage+dune";
     mk_test valid "Multiple identical suffixes" "1.0+dune+dune";
+    mk_test valid "+dune+mirage suffix" "1.0+dune+mirage";
+    mk_test valid "+duneX+mirageY suffix" "1.0+dune1+mirage2";
     mk_test invalid "Non-alphanumeric revised" "1.0+duneN";
     mk_test invalid "Missing suffix" "1.0";
     mk_test invalid "Not a suffix" "+dune1.0";
     mk_test invalid "Whitespace suffix" "1.0+dune ";
+    mk_test invalid "+mirage suffix alone" "1.0+mirage";
   ]
 
 let tests = ("version", test_cases)


### PR DESCRIPTION
See https://github.com/dune-universe/opam-overlays/pull/252

The goal is to merge [mirage-opam-overlays](https://github.com/dune-universe/mirage-opam-overlays) (which allows +mirage suffixes) to [opam-overlays](https://github.com/dune-universe/opam-overlays)